### PR TITLE
Todays games

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,29 @@
+name: Test PR
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Run script-new.rb
+        run: ruby script-new.rb
+
+      - name: Validate ERB templates
+        run: |
+          erb -x -T '-' standings.html.erb | ruby -c
+          erb -x -T '-' today.html.erb | ruby -c

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # hockey_bet
 
 Tracking a set of teams on a pages site as they advance towards the NHL Finals.
+
+## Running Tests Locally
+
+To ensure the HTML generation and ERB templates are functioning correctly, you can run tests locally before submitting a pull request. Follow these steps:
+
+1. Install Ruby using the version specified in the `.ruby-version` file.
+2. Install dependencies by running `bundle install`.
+3. Execute the script with `ruby script-new.rb` to generate the HTML files.
+
+This process will help identify any issues with the HTML generation or ERB templates before they are integrated into the main branch.

--- a/script-new.rb
+++ b/script-new.rb
@@ -12,11 +12,20 @@ def fetch_team_info
   response.code == 200 ? JSON.parse(response.body)["standings"] : []
 end
 
-# Fetch Schedule Information
+# Fetch Schedule Information with Redirect Handling
 def fetch_schedule_info
   url = "https://api-web.nhle.com/v1/schedule/now"
-  response = HTTParty.get(url)
-  response.code == 200 ? JSON.parse(response.body)["gameWeek"] : []
+  response = HTTParty.get(url, follow_redirects: true)
+  if response.code == 200
+    schedule_data = JSON.parse(response.body)
+    if schedule_data["gameWeek"].any?
+      schedule_data["gameWeek"]
+    else
+      []
+    end
+  else
+    []
+  end
 end
 
 # Map Managers to Teams

--- a/standings.html.erb
+++ b/standings.html.erb
@@ -17,6 +17,9 @@
 </head>
 <body class='m-2' data-color-mode='auto' data-light-theme='light' data-dark-theme='dark_dimmed'>
     <h1 class='color-fg-success'>Hockey Team Standings</h1>
+    <% if @today_games.any? %>
+        <a href='today.html' class='btn btn-primary mb-3'>See Today's Games</a>
+    <% end %>
     <table class='color-shadow-large'>
         <thead class='color-bg-accent-emphasis color-fg-on-emphasis mr-1'>
             <tr>

--- a/today.html.erb
+++ b/today.html.erb
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Today's NHL Games</title>
+    <link rel='stylesheet' href='https://unpkg.com/@primer/css@^20.2.4/dist/primer.css'>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body class='m-2' data-color-mode='auto' data-light-theme='light' data-dark-theme='dark_dimmed'>
+    <h1 class='color-fg-success'>Today's NHL Games</h1>
+    <table class='color-shadow-large'>
+        <thead class='color-bg-accent-emphasis color-fg-on-emphasis mr-1'>
+            <tr>
+                <th scope='col' class='p-2 border'>Game</th>
+                <th scope='col' class='p-2 border'>Time</th>
+                <th scope='col' class='p-2 border'>Teams</th>
+                <th scope='col' class='p-2 border'>Venue</th>
+            </tr>
+        </thead>
+        <tbody>
+            <% @today_games.each do |game| %>
+                <tr>
+                    <td class='p-2 border'><%= game[:id] %></td>
+                    <td class='p-2 border'><%= game[:startTimeUTC] %></td>
+                    <td class='p-2 border'><%= game[:awayTeam][:placeName][:default] %> vs <%= game[:homeTeam][:placeName][:default] %></td>
+                    <td class='p-2 border'><%= game[:venue][:default] %></td>
+                </tr>
+            <% end %>
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
Related to #43

This pull request introduces enhancements to the "Today's Games" section by implementing redirect handling for the NHL schedule API request and adding a new page to display today's games.

- Modifies `fetch_schedule_info` in `script-new.rb` to handle HTTP redirects when requesting the NHL schedule API, ensuring the method follows redirects until the final destination URL is reached and parses the final response to extract games data.
- Adds a new ERB template file `today.html.erb` to display today's games in a clean table format, including game ID, start time, teams, and venue.
- Updates `standings.html.erb` to include a link to the new "Today's Games" page if there are games scheduled for today, enhancing the user experience by providing easy access to daily game schedules.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/djdefi/hockey_bet/issues/43?shareId=91672f53-fa90-47a7-b35e-de16fb7d3dd7).