### PR TITLE
Fix handling of TBD games in standings

### DIFF
--- a/standings.html.erb
+++ b/standings.html.erb
@@ -72,7 +72,7 @@
                     <td class='p-2 border mobile-hidden'><%= team['divisionName'] %></td>
                     <td class='p-2 border mobile-hidden'><%= team['divisionSequence'] %></td>
                     <td class='p-2 border mobile-hidden'><%= team['wildcardSequence'] %></td>
-                    <td class='p-2 border'><%= next_game_pacific ? next_game_pacific.strftime('%-m/%-d %H:%M') : 'TBD' %></td>
+                    <td class='p-2 border'><%= next_game_pacific != 'TBD' ? next_game_pacific.strftime('%-m/%-d %H:%M') : 'TBD' %></td>
                     <td class='p-2 border'><%= next_games[team['teamAbbrev']['default']] ? (next_games[team['teamAbbrev']['default']]['awayTeam']['abbrev'] == team['teamAbbrev']['default'] ? next_games[team['teamAbbrev']['default']]['homeTeam']['placeName']['default'] : next_games[team['teamAbbrev']['default']]['awayTeam']['placeName']['default']) : 'TBD' %></td>
                 </tr>
             <% end %>

--- a/standings.html.erb
+++ b/standings.html.erb
@@ -72,7 +72,7 @@
                     <td class='p-2 border mobile-hidden'><%= team['divisionName'] %></td>
                     <td class='p-2 border mobile-hidden'><%= team['divisionSequence'] %></td>
                     <td class='p-2 border mobile-hidden'><%= team['wildcardSequence'] %></td>
-                    <td class='p-2 border'><%= next_game_pacific != 'TBD' ? next_game_pacific.strftime('%-m/%-d %H:%M') : 'TBD' %></td>
+                    <td class='p-2 border'><%= next_game_pacific && next_game_pacific != 'TBD' ? next_game_pacific.strftime('%-m/%-d %H:%M') : 'TBD'
                     <td class='p-2 border'><%= next_games[team['teamAbbrev']['default']] ? (next_games[team['teamAbbrev']['default']]['awayTeam']['abbrev'] == team['teamAbbrev']['default'] ? next_games[team['teamAbbrev']['default']]['homeTeam']['placeName']['default'] : next_games[team['teamAbbrev']['default']]['awayTeam']['placeName']['default']) : 'TBD' %></td>
                 </tr>
             <% end %>


### PR DESCRIPTION
Related to #52

Fixes the issue where the application crashes when attempting to format 'TBD' as a date.

- Adds a conditional check in `standings.html.erb` to ensure `strftime` is only called on `next_game_pacific` if it is not equal to 'TBD'. This prevents the `NoMethodError` when attempting to call `strftime` on a string.
- Ensures that 'TBD' is displayed as is for the 'Next Game' column without attempting to format it as a date.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/djdefi/hockey_bet/issues/52?shareId=ac28a839-a133-4975-b767-fa4bd4fb3c44).