### PR TITLE
Fix timezone discrepancy between last updated and next game

### DIFF
--- a/script-new.rb
+++ b/script-new.rb
@@ -84,7 +84,7 @@ next_games = find_next_games(teams, schedule)
 manager_team_map = map_managers_to_teams("fan_team.csv", teams)
 
 # Fetch the current time and store it in a variable
-last_updated = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S")
+last_updated = convert_utc_to_pacific(Time.now.utc.strftime("%Y-%m-%d %H:%M:%S"))
 
 # Debugging output
 puts "Teams: #{teams.inspect}"

--- a/standings.html.erb
+++ b/standings.html.erb
@@ -18,7 +18,7 @@
 </head>
 <body class='m-2' data-color-mode='auto' data-light-theme='light' data-dark-theme='dark_dimmed'>
     <h1 class='color-fg-success'>Hockey Team Standings</h1>
-    <p>Last updated at: <%= Time.parse(last_updated).localtime.strftime("%Y-%m-%d %H:%M:%S") %></p>
+    <p>Last updated at: <%= Time.parse(last_updated).strftime("%Y-%m-%d %H:%M:%S") %></p>
     <table class='color-shadow-large'>
         <thead class='color-bg-accent-emphasis color-fg-on-emphasis mr-1'>
             <tr>


### PR DESCRIPTION
Convert `last_updated` to Pacific time in `script-new.rb` and update its display in `standings.html.erb`.

* **script-new.rb**
  - Convert `last_updated` to Pacific time using `convert_utc_to_pacific` function.

* **standings.html.erb**
  - Update the display of `last_updated` to show Pacific time.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/djdefi/hockey_bet?shareId=6a669619-d22b-45f7-b500-db6c762cc752).