### PR TITLE
Fix build error caused by TypeError in time.rb

### DIFF
--- a/script-new.rb
+++ b/script-new.rb
@@ -44,7 +44,7 @@ end
 
 # Time Conversion
 def convert_utc_to_pacific(utc_time_str)
-  utc_time = Time.parse(utc_time_str)
+  utc_time = Time.parse(utc_time_str.to_s)
   tz = TZInfo::Timezone.get('America/Los_Angeles')
   pacific_time = tz.utc_to_local(utc_time)
   pacific_time

--- a/standings.html.erb
+++ b/standings.html.erb
@@ -18,7 +18,7 @@
 </head>
 <body class='m-2' data-color-mode='auto' data-light-theme='light' data-dark-theme='dark_dimmed'>
     <h1 class='color-fg-success'>Hockey Team Standings</h1>
-    <p>Last updated at: <%= Time.parse(last_updated).strftime("%Y-%m-%d %H:%M:%S") %></p>
+    <p>Last updated at: <%= Time.parse(last_updated.to_s).strftime("%Y-%m-%d %H:%M:%S") %></p>
     <table class='color-shadow-large'>
         <thead class='color-bg-accent-emphasis color-fg-on-emphasis mr-1'>
             <tr>


### PR DESCRIPTION
Fix build error caused by TypeError in `time.rb`.

* Update `convert_utc_to_pacific` method in `script-new.rb` to convert `TZInfo::TimeWithOffset` to string before passing to `Time.parse`.
* Update `Time.parse` method in `standings.html.erb` to correctly parse the string representation of `TZInfo::TimeWithOffset` object.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/djdefi/hockey_bet?shareId=bded29b2-2fe1-4654-9c6e-af1440a96a9a).