### PR TITLE
Add indicator for matches between fan teams

### DIFF
--- a/standings.html.erb
+++ b/standings.html.erb
@@ -75,7 +75,10 @@
                     <td class='p-2 border mobile-hidden'><%= team['divisionSequence'] || 'N/A' %></td>
                     <td class='p-2 border mobile-hidden'><%= team['wildcardSequence'] || 'N/A' %></td>
                     <td class='p-2 border'><%= next_game_pacific && next_game_pacific != 'TBD' ? next_game_pacific.strftime('%-m/%-d %H:%M') : 'TBD' %></td>
-                    <td class='p-2 border'><%= next_games[team['teamAbbrev']['default']] ? (next_games[team['teamAbbrev']['default']]['awayTeam']['abbrev'] == team['teamAbbrev']['default'] ? next_games[team['teamAbbrev']['default']]['homeTeam']['placeName']['default'] : next_games[team['teamAbbrev']['default']]['awayTeam']['placeName']['default']) : 'TBD' %></td>
+                    <td class='p-2 border'>
+                        <%= next_games[team['teamAbbrev']['default']] ? (next_games[team['teamAbbrev']['default']]['awayTeam']['abbrev'] == team['teamAbbrev']['default'] ? next_games[team['teamAbbrev']['default']]['homeTeam']['placeName']['default'] : next_games[team['teamAbbrev']['default']]['awayTeam']['placeName']['default']) : 'TBD' %>
+                        <%= next_games[team['teamAbbrev']['default']] && next_games[team['teamAbbrev']['default']]['isFanTeamOpponent'] ? '🔥' : '' %>
+                    </td>
                 </tr>
             <% end %>
         </tbody>


### PR DESCRIPTION
Add logic to display an emoji indicator for matches between fan teams.

* **script-new.rb**
  - Add `check_fan_team_opponent` function to check if the next opponent is a fan team and set an indicator.
  - Update `render_template` function to pass the indicator to the template.
  - Modify `next_games` initialization to include `isFanTeamOpponent` key.
  - Call `check_fan_team_opponent` function before rendering the template.

* **standings.html.erb**
  - Add logic to display an emoji (🔥) for matches between fan teams in the next opponent column.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/djdefi/hockey_bet?shareId=6d99c001-7963-4382-888b-3ab429182f84).