### PR TITLE
Fix not seeing the 🔥 in the Next opponent column

### DIFF
--- a/script-new.rb
+++ b/script-new.rb
@@ -47,7 +47,8 @@ def check_fan_team_opponent(next_games, manager_team_map)
   next_games.each do |team_id, game|
     if game
       opponent_id = game['awayTeam']['abbrev'] == team_id ? game['homeTeam']['abbrev'] : game['awayTeam']['abbrev']
-      game['isFanTeamOpponent'] = manager_team_map.values.include?(opponent_id)
+      opponent_team_name = game['awayTeam']['abbrev'] == team_id ? game['homeTeam']['placeName']['default'] : game['awayTeam']['placeName']['default']
+      game['isFanTeamOpponent'] = manager_team_map.keys.include?(opponent_team_name)
     else
       game['isFanTeamOpponent'] = false
     end


### PR DESCRIPTION
Update `check_fan_team_opponent` function in `script-new.rb` to correctly set the `isFanTeamOpponent` flag.

* Correctly match the `opponent_id` with the fan teams by using `opponent_team_name` in the `check_fan_team_opponent` function.
* Set `isFanTeamOpponent` flag to true if `opponent_team_name` is included in `manager_team_map` keys.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/djdefi/hockey_bet?shareId=c415e2d6-ad0d-4f29-8826-fb959d32fef1).