### PR TITLE
Fix toggle teams without fans functionality

### DIFF
--- a/standings.html.erb
+++ b/standings.html.erb
@@ -95,7 +95,7 @@
     document.getElementById('toggleButton').addEventListener('click', function () {
         var noFanRows = document.querySelectorAll('.no-fan-name');
         noFanRows.forEach(function (row) {
-            row.style.display = (row.style.display === 'none') ? 'table-row' : 'none';
+            row.style.display = (row.style.display === 'none' || row.style.display === '') ? 'table-row' : 'none';
         });
     });
 


### PR DESCRIPTION
Update the JavaScript code in `standings.html.erb` to correctly toggle the display of rows with the `no-fan-name` class.

* Modify the `row.style.display` condition to handle both 'none' and empty string cases, ensuring proper toggling of rows with the `no-fan-name` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/djdefi/hockey_bet/pull/76?shareId=931ec60c-a1f4-4183-9ac7-e5219daa2ecd).