### PR TITLE
Fix toggle teams without fans

### DIFF
--- a/script-new.rb
+++ b/script-new.rb
@@ -42,6 +42,13 @@ def map_managers_to_teams(csv_file, teams)
       manager_team_map["N/A"] = manager
     end
   end
+
+  # Include all teams in the manager_team_map
+  teams.each do |team|
+    abbreviation = team['teamAbbrev']['default']
+    manager_team_map[abbreviation] ||= "N/A"
+  end
+
   manager_team_map
 end
 

--- a/standings.html.erb
+++ b/standings.html.erb
@@ -57,7 +57,7 @@
                 next_game_utc = next_games[team['teamAbbrev']['default']] ? next_games[team['teamAbbrev']['default']]['startTimeUTC'] : nil
                 next_game_pacific = next_game_utc ? convert_utc_to_pacific(next_game_utc) : 'TBD'
                 %>
-                <tr class='<%= row_class %> <%= manager_team_map[team['teamAbbrev']['default']] == "N/A" ? 'no-fan-name' : '' %>'>
+                <tr class='<%= row_class %> <%= manager_team_map[team['teamAbbrev']['default']].nil? ? 'no-fan-name' : '' %>'>
                     <td class='p-2 border'><%= team['teamName']['default'] || 'N/A' %></td>
                     <td class='p-2 border'><%= manager_team_map[team['teamAbbrev']['default']] || 'N/A' %></td>
                     <td class='p-2 border'><%= team['wins'] || 'N/A' %></td>


### PR DESCRIPTION
Update the logic to correctly identify and hide teams that have a fan when the toggle button is clicked.

* **script-new.rb**
  - Include all teams in the `manager_team_map` by iterating through the `teams` array and setting the value to "N/A" if not already present.

* **standings.html.erb**
  - Update the class assignment logic to apply the `no-fan-name` class to rows where the `manager_team_map` value is nil instead of "N/A".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/djdefi/hockey_bet/pull/77?shareId=6e7ada44-c6f9-4afb-a403-d3568900d867).