### PR TITLE
Modernize PWA refresh flow and local validation

### DIFF
--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -467,7 +467,7 @@ function trapFocus(element) {
 ### Core Web Vitals Targets
 
 - **LCP (Largest Contentful Paint)**: < 2.5s
-- **FID (First Input Delay)**: < 100ms
+- **INP (Interaction to Next Paint)**: < 200ms
 - **CLS (Cumulative Layout Shift)**: < 0.1
 
 ### CSS Performance

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'httparty'
 gem 'csv'
 gem 'tzinfo'
+gem 'logger' # Required for Ruby 4.0+
 gem 'base64' # Required for Ruby 3.4+
 gem 'bigdecimal' # Required for Ruby 3.4+
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,9 +30,12 @@ GEM
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     ice_nine (0.11.2)
+    logger (1.7.0)
     mini_mime (1.1.5)
     multi_xml (0.8.1)
       bigdecimal (>= 3.1, < 5)
+    nokogiri (1.19.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
@@ -65,6 +68,7 @@ GEM
       descendants_tracker (~> 0.0, >= 0.0.3)
 
 PLATFORMS
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
@@ -73,6 +77,7 @@ DEPENDENCIES
   bigdecimal
   csv
   httparty
+  logger
   nokogiri
   rspec
   simplecov

--- a/MOBILE_EXPERIENCE_GUIDE.md
+++ b/MOBILE_EXPERIENCE_GUIDE.md
@@ -43,7 +43,7 @@ This document provides a comprehensive guide to the mobile experience enhancemen
 - **Critical CSS Inlining**: 324 bytes of essential styles inline in `<head>`
 - **Async CSS Loading**: Full stylesheet loads without blocking render
 - **Resource Hints**: Preconnect to fonts.googleapis.com and fonts.gstatic.com
-- **Core Web Vitals Monitoring**: Tracks LCP, FID, CLS in development
+- **Core Web Vitals Monitoring**: Tracks LCP, INP, and CLS in development
 - **Lazy Loading Helper**: Intersection Observer for future image optimization
 - **Network-Aware Loading**: Detects connection speed (2G/3G/4G)
 - **Data Caching**: Simple in-memory cache with configurable TTL
@@ -52,7 +52,7 @@ This document provides a comprehensive guide to the mobile experience enhancemen
 ```javascript
 // Core Web Vitals Tracking
 window.perfUtils.getMetrics()
-// Returns: { lcp: 1234, fid: 12, cls: 0.05 }
+// Returns: { lcp: 1234, inp: 75, cls: 0.05 }
 
 // Data Caching
 window.cacheHelper.get('standings', fetchStandings, 5 * 60 * 1000)
@@ -65,7 +65,7 @@ window.networkInfo.isFast() // true on 4g
 
 **Performance Targets:**
 - LCP (Largest Contentful Paint): <2.5s ✅
-- FID (First Input Delay): <100ms ✅
+- INP (Interaction to Next Paint): <200ms ✅
 - CLS (Cumulative Layout Shift): <0.1 ✅
 - Initial CSS Load: Instant (inlined) ✅
 
@@ -223,7 +223,7 @@ Total: ~40 KB (defer-loaded, non-blocking)
 - **Initial CSS Render**: <100ms (critical CSS inlined)
 - **Full Page Load**: ~1.2s (optimized resources)
 - **LCP**: <2.5s ✅
-- **FID**: <100ms ✅
+- **INP**: <200ms ✅
 - **CLS**: <0.1 ✅
 - **Monitoring**: Active (Web Vitals tracked)
 
@@ -286,7 +286,7 @@ Total: ~40 KB (defer-loaded, non-blocking)
 
 ### Technical Metrics
 - **Load Time**: -20% (critical CSS)
-- **Interaction Delay**: <100ms (FID)
+- **Interaction Delay**: <200ms (INP)
 - **Layout Stability**: <0.1 (CLS)
 - **Accessibility**: WCAG 2.1 AA compliant
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,18 @@ A live NHL standings tracker with playoff status indicators, fan ownership track
 
 ### Prerequisites
 
-- Ruby 3.0+ with Bundler
+- Ruby 3.4+ with Bundler 2.7.x
+- Node.js 20+
 - Basic knowledge of CSV for team mapping
 
 ### Installation
 
 1. Clone this repository
 2. Install dependencies:
-   ```
-   bundle install
-   ```
+    ```
+    bundle install
+    npm install
+    ```
 
 3. Edit `fan_team.csv` to map your fantasy league members to NHL teams:
    ```
@@ -34,10 +36,10 @@ A live NHL standings tracker with playoff status indicators, fan ownership track
    Bob,Maple Leafs
    ```
 
-4. Run the update script:
-   ```
-   ruby update_standings.rb
-   ```
+4. Build the site:
+    ```
+    npm run build
+    ```
 
 5. Open `_site/index.html` in your browser to view the standings
 
@@ -83,8 +85,11 @@ The "team" column can use full names, city names, or common nicknames - the syst
 ### Running Tests
 
 ```
-bundle exec rspec
+npm run test:ruby
+npm run test:e2e
 ```
+
+`npm run test:e2e` now builds the static site before Playwright starts its local server, so end-to-end runs always exercise a fresh `_site/` output instead of whatever happened to be generated earlier.
 
 Code coverage reports are automatically generated in the `coverage/` directory.
 

--- a/lib/app-assets.json
+++ b/lib/app-assets.json
@@ -1,0 +1,96 @@
+{
+  "stylesheets": [
+    {
+      "href": "styles.css",
+      "rel": "stylesheet"
+    }
+  ],
+  "external_scripts": [
+    {
+      "src": "https://code.iconify.design/iconify-icon/2.2.0/iconify-icon.min.js",
+      "defer": true
+    }
+  ],
+  "local_scripts": [
+    {
+      "src": "vendor/chart.umd.js",
+      "defer": true
+    },
+    {
+      "src": "performance-utils.js",
+      "defer": true
+    },
+    {
+      "src": "accessibility.js",
+      "defer": true
+    },
+    {
+      "src": "social-features.js",
+      "defer": true
+    },
+    {
+      "src": "mobile-gestures.js",
+      "defer": true
+    },
+    {
+      "src": "pwa-install.js",
+      "defer": true
+    },
+    {
+      "src": "team-themes.js",
+      "defer": true
+    },
+    {
+      "src": "team-picker.js",
+      "defer": true
+    }
+  ],
+  "copy": {
+    "vendor": [
+      "chart.umd.js",
+      "primer.css"
+    ],
+    "css": [
+      "styles.css",
+      "design-tokens.css",
+      "utilities.css",
+      "playoff_styles.css"
+    ],
+    "js": [
+      "performance-utils.js",
+      "accessibility.js",
+      "social-features.js",
+      "mobile-gestures.js",
+      "pwa-install.js",
+      "team-themes.js",
+      "team-picker.js"
+    ],
+    "root": [
+      "favicon.ico",
+      "icon.svg",
+      "site.webmanifest"
+    ]
+  },
+  "precache_paths": [
+    "./",
+    "./index.html",
+    "./standings.html",
+    "./playoffs.html",
+    "./styles.css",
+    "./design-tokens.css",
+    "./utilities.css",
+    "./playoff_styles.css",
+    "./favicon.ico",
+    "./icon.svg",
+    "./site.webmanifest",
+    "./app-assets.json",
+    "./vendor/chart.umd.js",
+    "./performance-utils.js",
+    "./accessibility.js",
+    "./social-features.js",
+    "./mobile-gestures.js",
+    "./pwa-install.js",
+    "./team-themes.js",
+    "./team-picker.js"
+  ]
+}

--- a/lib/app_assets.rb
+++ b/lib/app_assets.rb
@@ -1,0 +1,43 @@
+require 'json'
+
+module AppAssets
+  MANIFEST_PATH = File.expand_path('app-assets.json', __dir__)
+
+  module_function
+
+  def manifest
+    @manifest ||= JSON.parse(File.read(MANIFEST_PATH, encoding: 'UTF-8'))
+  end
+
+  def manifest_json
+    JSON.pretty_generate(manifest)
+  end
+
+  def stylesheets
+    manifest.fetch('stylesheets')
+  end
+
+  def external_scripts
+    manifest.fetch('external_scripts')
+  end
+
+  def local_scripts
+    manifest.fetch('local_scripts')
+  end
+
+  def css_files
+    manifest.fetch('copy').fetch('css')
+  end
+
+  def js_files
+    manifest.fetch('copy').fetch('js')
+  end
+
+  def vendor_files
+    manifest.fetch('copy').fetch('vendor')
+  end
+
+  def root_files
+    manifest.fetch('copy').fetch('root')
+  end
+end

--- a/lib/performance-utils.js
+++ b/lib/performance-utils.js
@@ -1,21 +1,31 @@
 /**
- * Performance Utilities - Simple client-side performance monitoring
+ * Performance Utilities - client-side performance monitoring
  * Tracks Core Web Vitals and provides lazy loading helpers
  */
 
 (function() {
   'use strict';
-  
+
+  const devHostPattern = /^(localhost|127\.0\.0\.1)(:\d+)?$/;
+
   // Core Web Vitals Monitoring
   const perfObserver = {
     lcp: null,
-    fid: null,
+    inp: null,
     cls: 0,
-    
+    fallbackInputDelay: null,
+    supportsINP: false,
+
     init: function() {
       if (!window.PerformanceObserver) return;
-      
-      // Largest Contentful Paint (LCP)
+
+      this.observeLCP();
+      this.observeINP();
+      this.observeCLS();
+      this.observeLifecycle();
+    },
+
+    observeLCP: function() {
       try {
         const lcpObserver = new PerformanceObserver((list) => {
           const entries = list.getEntries();
@@ -23,22 +33,51 @@
           this.lcp = lastEntry.renderTime || lastEntry.loadTime;
         });
         lcpObserver.observe({ type: 'largest-contentful-paint', buffered: true });
-      } catch (e) {
+      } catch (error) {
         // LCP not supported
       }
-      
-      // First Input Delay (FID)
+    },
+
+    observeINP: function() {
+      const supportedEntryTypes = window.PerformanceObserver.supportedEntryTypes || [];
+      if (!supportedEntryTypes.includes('event')) {
+        this.observeFirstInputFallback();
+        return;
+      }
+
+      try {
+        const inpObserver = new PerformanceObserver((list) => {
+          list.getEntries().forEach((entry) => {
+            if (!entry.interactionId || typeof entry.duration !== 'number') {
+              return;
+            }
+
+            if (this.inp === null || entry.duration > this.inp) {
+              this.inp = entry.duration;
+            }
+          });
+        });
+
+        inpObserver.observe({ type: 'event', buffered: true, durationThreshold: 40 });
+        this.supportsINP = true;
+      } catch (error) {
+        this.observeFirstInputFallback();
+      }
+    },
+
+    observeFirstInputFallback: function() {
       try {
         const fidObserver = new PerformanceObserver((list) => {
           const firstInput = list.getEntries()[0];
-          this.fid = firstInput.processingStart - firstInput.startTime;
+          this.fallbackInputDelay = firstInput.processingStart - firstInput.startTime;
         });
         fidObserver.observe({ type: 'first-input', buffered: true });
-      } catch (e) {
-        // FID not supported
+      } catch (error) {
+        // Fallback metric not supported
       }
-      
-      // Cumulative Layout Shift (CLS)
+    },
+
+    observeCLS: function() {
       try {
         const clsObserver = new PerformanceObserver((list) => {
           for (const entry of list.getEntries()) {
@@ -48,40 +87,45 @@
           }
         });
         clsObserver.observe({ type: 'layout-shift', buffered: true });
-      } catch (e) {
+      } catch (error) {
         // CLS not supported
       }
     },
-    
+
+    observeLifecycle: function() {
+      const logMetrics = () => this.logMetrics();
+
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') {
+          logMetrics();
+        }
+      });
+
+      window.addEventListener('pagehide', logMetrics);
+    },
+
     getMetrics: function() {
       return {
         lcp: this.lcp ? Math.round(this.lcp) : null,
-        fid: this.fid ? Math.round(this.fid) : null,
-        cls: Math.round(this.cls * 1000) / 1000
+        inp: this.inp ? Math.round(this.inp) : null,
+        cls: Math.round(this.cls * 1000) / 1000,
+        fallbackInputDelay: this.fallbackInputDelay ? Math.round(this.fallbackInputDelay) : null,
+        supportsINP: this.supportsINP
       };
     },
-    
+
     logMetrics: function() {
-      // Only log in development (handle variations like 127.0.0.1:8080)
-      const devHostPattern = /^(localhost|127\.0\.0\.1)(:\d+)?$/;
       if (devHostPattern.test(window.location.host)) {
         console.debug('Core Web Vitals:', this.getMetrics());
       }
     }
   };
-  
-  // Initialize monitoring
+
   perfObserver.init();
-  
-  // Log metrics when page is about to unload
-  window.addEventListener('beforeunload', function() {
-    perfObserver.logMetrics();
-  });
-  
+
   // Lazy Loading Helper (for future image optimization)
   const lazyLoader = {
     init: function() {
-      // Use Intersection Observer for lazy loading
       if ('IntersectionObserver' in window) {
         const imageObserver = new IntersectionObserver((entries, observer) => {
           entries.forEach(entry => {
@@ -95,16 +139,14 @@
             }
           });
         }, {
-          rootMargin: '50px 0px', // Start loading 50px before entering viewport
+          rootMargin: '50px 0px',
           threshold: 0.01
         });
-        
-        // Observe all images with data-src attribute
+
         document.querySelectorAll('img[data-src]').forEach(img => {
           imageObserver.observe(img);
         });
       } else {
-        // Fallback: load all images immediately
         document.querySelectorAll('img[data-src]').forEach(img => {
           img.src = img.dataset.src;
           img.removeAttribute('data-src');
@@ -112,8 +154,7 @@
       }
     }
   };
-  
-  // Initialize lazy loading when DOM is ready
+
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', function() {
       lazyLoader.init();
@@ -121,40 +162,37 @@
   } else {
     lazyLoader.init();
   }
-  
-  // Expose utilities globally
+
   window.perfUtils = {
     getMetrics: perfObserver.getMetrics.bind(perfObserver),
     logMetrics: perfObserver.logMetrics.bind(perfObserver),
     lazyLoad: lazyLoader.init.bind(lazyLoader)
   };
-  
-  // Simple caching helper for data fetches
+
   window.cacheHelper = {
     cache: new Map(),
-    maxSize: 50, // Maximum number of cache entries
-    
-    get: function(key, fetchFn, ttl = 5 * 60 * 1000) { // 5 minutes default
+    maxSize: 50,
+
+    get: function(key, fetchFn, ttl) {
+      const effectiveTTL = typeof ttl === 'number' ? ttl : 5 * 60 * 1000;
       const cached = this.cache.get(key);
       const now = Date.now();
-      
-      // Check if cached and not expired
-      if (cached && (now - cached.timestamp) < ttl) {
+
+      if (cached && (now - cached.timestamp) < effectiveTTL) {
         return Promise.resolve(cached.data);
       }
-      
+
       return fetchFn().then(data => {
-        // Enforce size limit by removing oldest entries
         if (this.cache.size >= this.maxSize) {
           const oldestKey = this.cache.keys().next().value;
           this.cache.delete(oldestKey);
         }
-        
+
         this.cache.set(key, { data: data, timestamp: now });
         return data;
       });
     },
-    
+
     clear: function(key) {
       if (key) {
         this.cache.delete(key);
@@ -162,48 +200,43 @@
         this.cache.clear();
       }
     },
-    
-    // Cleanup expired entries
-    cleanupExpired: function(ttl = 5 * 60 * 1000) {
+
+    cleanupExpired: function(ttl) {
+      const effectiveTTL = typeof ttl === 'number' ? ttl : 5 * 60 * 1000;
       const now = Date.now();
       for (const [key, value] of this.cache.entries()) {
-        if (now - value.timestamp >= ttl) {
+        if (now - value.timestamp >= effectiveTTL) {
           this.cache.delete(key);
         }
       }
     }
   };
-  
-  // Periodically cleanup expired cache entries
+
   setInterval(() => {
     window.cacheHelper.cleanupExpired();
-  }, 5 * 60 * 1000); // Every 5 minutes
-  
-  // Network-aware loading (detect connection speed)
+  }, 5 * 60 * 1000);
+
   if ('connection' in navigator) {
     const connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
     const effectiveType = connection.effectiveType;
-    
-    // Add class to body for CSS conditionals
+
     if (effectiveType) {
       document.documentElement.classList.add('connection-' + effectiveType);
     }
-    
-    // Expose connection info
+
     window.networkInfo = {
       type: effectiveType,
       downlink: connection.downlink,
       rtt: connection.rtt,
       saveData: connection.saveData,
-      
+
       isSlow: function() {
         return effectiveType === 'slow-2g' || effectiveType === '2g';
       },
-      
+
       isFast: function() {
         return effectiveType === '4g';
       }
     };
   }
-  
 })();

--- a/lib/standings.html.erb
+++ b/lib/standings.html.erb
@@ -18,7 +18,9 @@
     <script><%= File.read("lib/theme-init.js", encoding: 'UTF-8') %></script>
     
     <!-- Load full styles synchronously for reliability -->
-    <link rel='stylesheet' href='styles.css'>
+    <% AppAssets.stylesheets.each do |stylesheet| %>
+    <link rel="<%= stylesheet['rel'] %>" href="<%= stylesheet['href'] %>">
+    <% end %>
     
     <link rel="icon" href="favicon.ico" type="image/x-icon">
     <link rel="icon" href="icon.svg" type="image/svg+xml">
@@ -36,32 +38,20 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="dns-prefetch" href="https://api-web.nhle.com">
     
-    <!-- Iconify Icon Web Component for Solar icons -->
-    <script src="https://code.iconify.design/iconify-icon/2.2.0/iconify-icon.min.js" defer></script>
-    
-    <!-- Chart.js - Vendored with deferred loading for performance -->
-    <script src="vendor/chart.umd.js" defer></script>
-    
-    <!-- Performance utilities - Core Web Vitals monitoring and lazy loading -->
-    <script src="performance-utils.js" defer></script>
-    
-    <!-- Accessibility enhancements - Keyboard shortcuts and focus management -->
-    <script src="accessibility.js" defer></script>
-    
-    <!-- Social features - Reactions, celebrations, and engagement -->
-    <script src="social-features.js" defer></script>
-    
-    <!-- Mobile Gestures - Enhanced touch interactions -->
-    <script src="mobile-gestures.js" defer></script>
-    
-    <!-- PWA Install Promotion - Smart "Add to Home Screen" banner -->
-    <script src="pwa-install.js" defer></script>
+    <script>
+        window.IconifyProviders = {
+            "": ["https://api.iconify.design"]
+        };
+        window.IconifyProviderFallback = {};
+    </script>
 
-    <!-- Team Theming - Dynamic team color themes -->
-    <script src="team-themes.js" defer></script>
-
-    <!-- Team Picker - Team allegiance selection modal -->
-    <script src="team-picker.js" defer></script>
+    <% AppAssets.external_scripts.each do |script| %>
+    <script src="<%= script['src'] %>"<%= script['defer'] ? ' defer' : '' %>></script>
+    <% end %>
+    
+    <% AppAssets.local_scripts.each do |script| %>
+    <script src="<%= script['src'] %>"<%= script['defer'] ? ' defer' : '' %>></script>
+    <% end %>
 </head>
 <body>
     <div class="app-accent-bar" aria-hidden="true"></div>
@@ -1686,12 +1676,42 @@
         // Don't load chart on page load - only when trends tab is clicked
         // Chart will be loaded by switchTab function
         
-        // Register Service Worker for offline caching and performance
+        // Register Service Worker for offline caching and reliable deploy updates
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
+                let hasReloadedForServiceWorker = false;
+
                 navigator.serviceWorker.register('./service-worker.js')
-                    .then(registration => console.log('ServiceWorker registered'))
-                    .catch(err => console.log('ServiceWorker registration failed:', err));
+                    .then((registration) => {
+                        registration.update();
+
+                        if (registration.waiting) {
+                            registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+                        }
+
+                        registration.addEventListener('updatefound', () => {
+                            const installingWorker = registration.installing;
+                            if (!installingWorker) {
+                                return;
+                            }
+
+                            installingWorker.addEventListener('statechange', () => {
+                                if (installingWorker.state === 'installed' && navigator.serviceWorker.controller && registration.waiting) {
+                                    registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+                                }
+                            });
+                        });
+                    })
+                    .catch((err) => console.warn('ServiceWorker registration failed:', err));
+
+                navigator.serviceWorker.addEventListener('controllerchange', () => {
+                    if (hasReloadedForServiceWorker) {
+                        return;
+                    }
+
+                    hasReloadedForServiceWorker = true;
+                    window.location.reload();
+                });
             });
         }
     </script>

--- a/lib/standings_processor.rb
+++ b/lib/standings_processor.rb
@@ -12,6 +12,7 @@ require_relative 'playoff_processor'
 require_relative 'bet_stats_calculator'
 require_relative 'standings_history_tracker'
 require_relative 'team_colors'
+require_relative 'app_assets'
 
 # Playoff Status Helper Structure
 # Enhanced with specific seed and position information
@@ -134,36 +135,41 @@ class StandingsProcessor
     vendor_dest_dir = "#{output_dir}/vendor"
     FileUtils.mkdir_p(vendor_dest_dir)
     
-    # Copy Chart.js and Primer CSS if they exist
-    ['chart.umd.js', 'primer.css'].each do |file|
+    # Copy vendor assets declared in the shared asset manifest
+    AppAssets.vendor_files.each do |file|
       src = File.join(vendor_src_dir, file)
       dest = File.join(vendor_dest_dir, file)
       FileUtils.cp(src, dest) if File.exist?(src)
     end
     
     # Copy CSS files from lib to output directory (styles.css imports design-tokens.css and utilities.css)
-    ['styles.css', 'design-tokens.css', 'utilities.css', 'playoff_styles.css'].each do |file|
+    AppAssets.css_files.each do |file|
       src = File.join(File.dirname(__FILE__), file)
       dest = "#{output_dir}/#{file}"
       FileUtils.cp(src, dest) if File.exist?(src)
     end
     
     # Copy JavaScript files from lib to output directory
-    ['mobile-gestures.js', 'performance-utils.js', 'accessibility.js', 'social-features.js', 'pwa-install.js', 'team-themes.js', 'team-picker.js'].each do |file|
+    AppAssets.js_files.each do |file|
       src = File.join(File.dirname(__FILE__), file)
       dest = "#{output_dir}/#{file}"
       FileUtils.cp(src, dest) if File.exist?(src)
     end
+
+    # Write the shared asset manifest used by the service worker and tests
+    File.write("#{output_dir}/app-assets.json", AppAssets.manifest_json)
     
     # Copy service worker for PWA and caching
     sw_src = 'service-worker.js'
     sw_dest = "#{output_dir}/service-worker.js"
     FileUtils.cp(sw_src, sw_dest) if File.exist?(sw_src)
     
-    # Copy web manifest for PWA
-    manifest_src = 'site.webmanifest'
-    manifest_dest = "#{output_dir}/site.webmanifest"
-    FileUtils.cp(manifest_src, manifest_dest) if File.exist?(manifest_src)
+    # Copy root-level assets required for installability and icon rendering
+    AppAssets.root_files.each do |file|
+      src = file
+      dest = "#{output_dir}/#{file}"
+      FileUtils.cp(src, dest) if File.exist?(src)
+    end
   end
 
   # Determine playoff status for a team with enhanced specificity

--- a/lib/theme-init.js
+++ b/lib/theme-init.js
@@ -1,18 +1,41 @@
 // Theme Init — runs inline (not deferred) to prevent flash of wrong theme
 (function() {
+  var STORAGE_KEY = 'nhl_fan_team_css';
+  var root = document.documentElement;
+  var devHostPattern = /^(localhost|127\.0\.0\.1)(:\d+)?$/;
+
+  root.dataset.themeSource = 'default';
+
   try {
-    var css = localStorage.getItem('nhl_fan_team_css');
-    if (css) {
-      var vars = JSON.parse(css);
-      var root = document.documentElement;
-      var keys = Object.keys(vars);
-      for (var i = 0; i < keys.length; i++) {
-        root.style.setProperty(keys[i], vars[keys[i]]);
-      }
-      var meta = document.querySelector('meta[name="theme-color"]');
-      if (meta && vars['--color-bg-primary']) {
-        meta.setAttribute('content', vars['--color-bg-primary']);
+    var css = localStorage.getItem(STORAGE_KEY);
+    if (!css) {
+      return;
+    }
+
+    var vars = JSON.parse(css);
+    if (!vars || typeof vars !== 'object' || Array.isArray(vars)) {
+      root.dataset.themeInitError = 'invalid-theme-payload';
+      return;
+    }
+
+    var keys = Object.keys(vars);
+    for (var i = 0; i < keys.length; i++) {
+      if (keys[i].indexOf('--') === 0) {
+        root.style.setProperty(keys[i], String(vars[keys[i]]));
       }
     }
-  } catch(e) { /* silent fail — default theme will show */ }
+
+    var meta = document.querySelector('meta[name="theme-color"]');
+    if (meta && vars['--color-bg-primary']) {
+      meta.setAttribute('content', String(vars['--color-bg-primary']));
+    }
+
+    root.dataset.themeSource = 'storage';
+  } catch (error) {
+    root.dataset.themeInitError = 'storage-parse';
+
+    if (devHostPattern.test(window.location.host)) {
+      console.warn('Theme init failed, falling back to default theme.', error);
+    }
+  }
 })();

--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
     "lib": "lib"
   },
   "scripts": {
-    "test": "npx playwright test",
+    "build": "bundle exec ruby update_standings.rb",
+    "serve:site": "npx serve _site -l 8765 --no-clipboard",
+    "test": "npm run test:e2e",
+    "test:ruby": "bundle exec rspec",
     "test:e2e": "npx playwright test",
+    "test:all": "npm run test:ruby && npm run test:e2e",
     "test:e2e:headed": "npx playwright test --headed",
     "test:e2e:desktop": "npx playwright test --project=desktop-chrome",
     "test:e2e:mobile": "npx playwright test --project=mobile-iphone",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,9 +27,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npx serve _site -l 8765 --no-clipboard',
+    command: 'bundle exec ruby update_standings.rb && npx serve _site -l 8765 --no-clipboard',
     port: 8765,
     reuseExistingServer: !process.env.CI,
-    timeout: 10000,
+    timeout: 45000,
   },
 });

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,28 +1,9 @@
-// Service Worker for Hockey Bet - Mobile Performance Optimization
-const CACHE_NAME = 'hockey-bet-v5';
-const DATA_CACHE_NAME = 'hockey-bet-data-v5';
+// Service Worker for Hockey Bet - installable shell + refresh-friendly caching
+const CACHE_NAME = 'hockey-bet-static-v6';
+const DATA_CACHE_NAME = 'hockey-bet-data-v6';
+const APP_ASSET_MANIFEST_URL = './app-assets.json';
+const LOCAL_ORIGIN = self.location.origin;
 
-// Assets to cache on install (using relative paths for GitHub Pages compatibility)
-const STATIC_ASSETS = [
-  './',
-  './index.html',
-  './styles.css',
-  './design-tokens.css',
-  './favicon.ico',
-  './icon.svg',
-  './site.webmanifest',
-  './theme-init.js',
-  './performance-utils.js',
-  './accessibility.js',
-  './social-features.js',
-  './mobile-gestures.js',
-  './pwa-install.js',
-  './team-themes.js',
-  './team-picker.js',
-  './vendor/chart.umd.js'
-];
-
-// Offline fallback page served when navigation fails without a cached response
 const OFFLINE_HTML = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -46,91 +27,161 @@ const OFFLINE_HTML = `<!DOCTYPE html>
 </body>
 </html>`;
 
-// Install event - cache static assets
+const OFFLINE_HTML_HEADERS = {
+  'Content-Type': 'text/html; charset=UTF-8'
+};
+
+function isSameOriginGetRequest(request) {
+  return request.method === 'GET' && new URL(request.url).origin === LOCAL_ORIGIN;
+}
+
+function isDataRequest(url) {
+  return url.pathname.endsWith('.json');
+}
+
+function isStaticAssetRequest(request, url) {
+  return ['script', 'style', 'image', 'font', 'manifest'].includes(request.destination) ||
+    /\.(?:css|js|ico|svg|png|webmanifest)$/i.test(url.pathname);
+}
+
+async function loadPrecachePaths() {
+  try {
+    const response = await fetch(APP_ASSET_MANIFEST_URL, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Unable to load ${APP_ASSET_MANIFEST_URL}: ${response.status}`);
+    }
+
+    const manifest = await response.json();
+    const paths = Array.isArray(manifest.precache_paths) ? manifest.precache_paths : [];
+    return [...new Set(paths)];
+  } catch (error) {
+    console.warn('ServiceWorker precache manifest unavailable:', error);
+    return ['./', './index.html', './site.webmanifest'];
+  }
+}
+
+async function precacheStaticAssets(cache) {
+  const paths = await loadPrecachePaths();
+
+  await Promise.allSettled(
+    paths.map(async (assetPath) => {
+      const request = new Request(assetPath, { cache: 'reload' });
+      const response = await fetch(request);
+      if (!response.ok) {
+        throw new Error(`Precache failed for ${assetPath}: ${response.status}`);
+      }
+
+      await cache.put(request, response.clone());
+    })
+  );
+}
+
+async function handleDataRequest(event) {
+  const cache = await caches.open(DATA_CACHE_NAME);
+  const cachedResponse = await cache.match(event.request);
+  const networkFetch = fetch(event.request).then((networkResponse) => {
+    if (networkResponse && networkResponse.ok) {
+      cache.put(event.request, networkResponse.clone());
+    }
+    return networkResponse;
+  });
+
+  if (cachedResponse) {
+    event.waitUntil(networkFetch.catch(() => undefined));
+    return cachedResponse;
+  }
+
+  try {
+    return await networkFetch;
+  } catch (error) {
+    return new Response(JSON.stringify({ error: 'offline' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}
+
+async function handleNavigationRequest(event) {
+  const cache = await caches.open(CACHE_NAME);
+
+  try {
+    const networkResponse = await fetch(event.request);
+    if (networkResponse && networkResponse.ok) {
+      await cache.put(event.request, networkResponse.clone());
+    }
+    return networkResponse;
+  } catch (error) {
+    const cachedResponse = await cache.match(event.request);
+    return cachedResponse || new Response(OFFLINE_HTML, { headers: OFFLINE_HTML_HEADERS });
+  }
+}
+
+async function handleStaticAssetRequest(event) {
+  const cache = await caches.open(CACHE_NAME);
+  const cachedResponse = await cache.match(event.request);
+  const networkFetch = fetch(event.request).then((networkResponse) => {
+    if (networkResponse && networkResponse.ok) {
+      cache.put(event.request, networkResponse.clone());
+    }
+    return networkResponse;
+  });
+
+  if (cachedResponse) {
+    event.waitUntil(networkFetch.catch(() => undefined));
+    return cachedResponse;
+  }
+
+  try {
+    return await networkFetch;
+  } catch (error) {
+    return cachedResponse || Response.error();
+  }
+}
+
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME)
-      .then((cache) => cache.addAll(STATIC_ASSETS))
+      .then((cache) => precacheStaticAssets(cache))
       .then(() => self.skipWaiting())
   );
 });
 
-// Activate event - clean up old caches
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys()
-      .then((cacheNames) => {
-        return Promise.all(
-          cacheNames
-            .filter((name) => name !== CACHE_NAME && name !== DATA_CACHE_NAME)
-            .map((name) => caches.delete(name))
-        );
-      })
+      .then((cacheNames) => Promise.all(
+        cacheNames
+          .filter((name) => name !== CACHE_NAME && name !== DATA_CACHE_NAME)
+          .map((name) => caches.delete(name))
+      ))
       .then(() => self.clients.claim())
   );
 });
 
-// Fetch event - stale-while-revalidate for data, cache-first for assets
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
 self.addEventListener('fetch', (event) => {
-  const { request } = event;
-  const url = new URL(request.url);
-
-  // Handle JSON data files with stale-while-revalidate
-  if (url.pathname.endsWith('.json')) {
-    event.respondWith(
-      caches.open(DATA_CACHE_NAME).then((cache) => {
-        return cache.match(request).then((cachedResponse) => {
-          const fetchPromise = fetch(request).then((networkResponse) => {
-            // Update cache with fresh data
-            cache.put(request, networkResponse.clone());
-            return networkResponse;
-          }).catch(() => cachedResponse); // Fallback to cache if network fails
-
-          // Return cached data immediately, update in background
-          return cachedResponse || fetchPromise;
-        });
-      })
-    );
+  if (!isSameOriginGetRequest(event.request)) {
     return;
   }
 
-  // Handle navigation requests with offline fallback
-  if (request.mode === 'navigate') {
-    event.respondWith(
-      fetch(request)
-        .then((response) => {
-          const responseToCache = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(request, responseToCache));
-          return response;
-        })
-        .catch(() => {
-          return caches.match(request).then((cached) => {
-            return cached || new Response(OFFLINE_HTML, {
-              headers: { 'Content-Type': 'text/html' }
-            });
-          });
-        })
-    );
+  const url = new URL(event.request.url);
+
+  if (isDataRequest(url)) {
+    event.respondWith(handleDataRequest(event));
     return;
   }
 
-  // Handle static assets with cache-first
-  event.respondWith(
-    caches.match(request).then((response) => {
-      if (response) {
-        return response;
-      }
+  if (event.request.mode === 'navigate') {
+    event.respondWith(handleNavigationRequest(event));
+    return;
+  }
 
-      return fetch(request).then((response) => {
-        // Cache successful responses
-        if (response.status === 200) {
-          const responseToCache = response.clone();
-          caches.open(CACHE_NAME).then((cache) => {
-            cache.put(request, responseToCache);
-          });
-        }
-        return response;
-      });
-    })
-  );
+  if (isStaticAssetRequest(event.request, url)) {
+    event.respondWith(handleStaticAssetRequest(event));
+  }
 });

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -21,7 +21,7 @@
   "display": "standalone",
   "orientation": "portrait-primary",
   "scope": "./",
-  "start_url": "./index.html",
+  "start_url": "./",
   "categories": ["sports", "entertainment"],
   "prefer_related_applications": false,
   "shortcuts": [

--- a/spec/end_to_end_spec.rb
+++ b/spec/end_to_end_spec.rb
@@ -6,10 +6,16 @@ require 'tmpdir'
 RSpec.describe 'End-to-End Generation and Rendering' do
   let(:output_dir) { Dir.mktmpdir }
   let(:output_path) { File.join(output_dir, 'index.html') }
+  let(:data_dir) { Dir.mktmpdir }
   let(:csv_path) { 'spec/fixtures/fan_team.csv' }
+
+  before do
+    stub_const('DATA_DIR', data_dir)
+  end
   
   after do
     FileUtils.rm_rf(output_dir) if Dir.exist?(output_dir)
+    FileUtils.rm_rf(data_dir) if Dir.exist?(data_dir)
   end
   
   describe 'Complete generation pipeline' do
@@ -53,6 +59,7 @@ RSpec.describe 'End-to-End Generation and Rendering' do
       # Verify all required assets were copied
       output_dir_path = File.dirname(output_path)
       expect(File.exist?(File.join(output_dir_path, 'styles.css'))).to be true
+      expect(File.exist?(File.join(output_dir_path, 'app-assets.json'))).to be true
       expect(Dir.exist?(File.join(output_dir_path, 'vendor'))).to be true
     end
     

--- a/spec/standings_spec.rb
+++ b/spec/standings_spec.rb
@@ -3,6 +3,7 @@ require 'tzinfo'
 require 'time'
 require 'json'
 require 'erb'
+require 'tmpdir'
 
 # Load the refactored script
 require_relative '../lib/standings_processor'
@@ -398,24 +399,25 @@ RSpec.describe 'NHL Standings Table' do
         
         # Mock the render_template method
         allow(processor).to receive(:render_template).and_return('HTML content')
-        
-        @temp_output = '/tmp/test_output.html'
+
+        @temp_root = Dir.mktmpdir
+        @temp_output = File.join(@temp_root, 'test_output.html')
+        @temp_data_dir = File.join(@temp_root, 'data')
+
+        stub_const('DATA_DIR', @temp_data_dir)
       end
 
       after do
-        File.delete(@temp_output) if File.exist?(@temp_output)
+        FileUtils.rm_rf(@temp_root) if @temp_root && Dir.exist?(@temp_root)
       end
 
       it 'creates output directory if needed' do
-        output_path = '/tmp/subdir/test.html'
+        output_path = File.join(@temp_root, 'nested', 'test.html')
         
         processor.render_output(output_path)
         
-        expect(Dir.exist?('/tmp/subdir')).to be true
+        expect(Dir.exist?(File.dirname(output_path))).to be true
         expect(File.exist?(output_path)).to be true
-        
-        # Cleanup - use rm_rf to remove directory and all contents
-        FileUtils.rm_rf('/tmp/subdir')
       end
 
       it 'writes HTML content to file' do
@@ -440,6 +442,20 @@ RSpec.describe 'NHL Standings Table' do
         File.delete(styles_path) if File.exist?(styles_path)
       end
 
+      it 'writes app-assets.json to output directory' do
+        processor.render_output(@temp_output)
+
+        output_dir = File.dirname(@temp_output)
+        asset_manifest_path = File.join(output_dir, 'app-assets.json')
+
+        expect(File.exist?(asset_manifest_path)).to be true
+        manifest = JSON.parse(File.read(asset_manifest_path))
+        expect(manifest['precache_paths']).to include('./site.webmanifest')
+        expect(manifest['precache_paths']).to include('./performance-utils.js')
+
+        File.delete(asset_manifest_path) if File.exist?(asset_manifest_path)
+      end
+
       it 'copies vendor assets to output directory' do
         processor.render_output(@temp_output)
         
@@ -452,6 +468,19 @@ RSpec.describe 'NHL Standings Table' do
         
         # Cleanup
         FileUtils.rm_rf(vendor_dir) if Dir.exist?(vendor_dir)
+      end
+
+      it 'copies root install assets to output directory' do
+        processor.render_output(@temp_output)
+
+        output_dir = File.dirname(@temp_output)
+        expect(File.exist?(File.join(output_dir, 'favicon.ico'))).to be true
+        expect(File.exist?(File.join(output_dir, 'icon.svg'))).to be true
+        expect(File.exist?(File.join(output_dir, 'site.webmanifest'))).to be true
+
+        File.delete(File.join(output_dir, 'favicon.ico')) if File.exist?(File.join(output_dir, 'favicon.ico'))
+        File.delete(File.join(output_dir, 'icon.svg')) if File.exist?(File.join(output_dir, 'icon.svg'))
+        File.delete(File.join(output_dir, 'site.webmanifest')) if File.exist?(File.join(output_dir, 'site.webmanifest'))
       end
     end
 
@@ -594,8 +623,10 @@ RSpec.describe 'NHL Standings Table' do
       # Mock the render_template method to return HTML content
       allow(processor).to receive(:render_template).and_return("<html>Test content</html>")
 
-      # Create a temporary output file
-      temp_output_path = 'spec/fixtures/temp_output.html'
+      temp_root = Dir.mktmpdir
+      temp_output_path = File.join(temp_root, 'temp_output.html')
+      temp_data_dir = File.join(temp_root, 'data')
+      stub_const('DATA_DIR', temp_data_dir)
 
       # Run the render_output method
       expect { processor.render_output(temp_output_path) }.not_to raise_error
@@ -604,7 +635,7 @@ RSpec.describe 'NHL Standings Table' do
       expect(File.exist?(temp_output_path)).to be true
 
       # Clean up
-      File.delete(temp_output_path) if File.exist?(temp_output_path)
+      FileUtils.rm_rf(temp_root) if Dir.exist?(temp_root)
     end
   end
 

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -467,15 +467,20 @@ test.describe('PWA Assets', () => {
     const fs = require('fs');
     const path = require('path');
     const sw = fs.readFileSync(path.resolve(__dirname, '..', 'service-worker.js'), 'utf-8');
+    const assetManifest = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '..', 'lib', 'app-assets.json'), 'utf-8')
+    );
 
     const expectedAssets = [
-      'team-themes.js', 'team-picker.js', 'social-features.js',
-      'mobile-gestures.js', 'pwa-install.js', 'accessibility.js',
-      'performance-utils.js', 'chart.umd.js'
+      './team-themes.js', './team-picker.js', './social-features.js',
+      './mobile-gestures.js', './pwa-install.js', './accessibility.js',
+      './performance-utils.js', './vendor/chart.umd.js'
     ];
     expectedAssets.forEach(asset => {
-      expect(sw).toContain(asset);
+      expect(assetManifest.precache_paths).toContain(asset);
     });
+
+    expect(sw).toContain('APP_ASSET_MANIFEST_URL');
   });
 
   test('service-worker has offline fallback', async ({ page }) => {

--- a/tests/deep.spec.js
+++ b/tests/deep.spec.js
@@ -360,18 +360,17 @@ test.describe('Mobile Gestures Edge Cases', () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 test.describe('Cross-File Consistency', () => {
-  test('all JS files referenced in standings.html.erb are in service worker cache', async () => {
-    const sw = fs.readFileSync(path.resolve(__dirname, '..', 'service-worker.js'), 'utf-8');
-    const erb = fs.readFileSync(path.resolve(__dirname, '..', 'lib', 'standings.html.erb'), 'utf-8');
+  test('all local scripts declared in app_assets are in precache_paths', async () => {
+    const assetManifest = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '..', 'lib', 'app-assets.json'), 'utf-8')
+    );
 
-    // Find all script src in ERB (excluding external URLs and inline)
-    const scriptMatches = erb.match(/src="([^"]+\.js)"/g) || [];
-    const localScripts = scriptMatches
-      .map(m => m.match(/src="([^"]+\.js)"/)[1])
-      .filter(s => !s.startsWith('http'));
+    const localScripts = assetManifest.local_scripts
+      .map(script => script.src)
+      .filter(src => !src.startsWith('http'));
 
     for (const script of localScripts) {
-      expect(sw).toContain(script);
+      expect(assetManifest.precache_paths).toContain('./' + script);
     }
   });
 

--- a/tests/integration.spec.js
+++ b/tests/integration.spec.js
@@ -181,12 +181,13 @@ test.describe('Service Worker Analysis', () => {
 
     // JSON handling (stale-while-revalidate)
     expect(sw).toContain('.json');
+    expect(sw).toContain('handleDataRequest');
 
     // Navigation handling (offline fallback)
     expect(sw).toContain("request.mode === 'navigate'");
 
     // Static asset handling (cache-first)
-    expect(sw).toContain('caches.match(request)');
+    expect(sw).toContain('handleStaticAssetRequest');
   });
 
   test('service worker activates correctly (claims clients)', () => {

--- a/tests/navigation.spec.js
+++ b/tests/navigation.spec.js
@@ -186,26 +186,31 @@ test.describe('switchTab API', () => {
 
 test.describe('Service Worker Cache', () => {
   test('service worker caches design-tokens.css', () => {
-    const sw = fs.readFileSync(path.resolve(__dirname, '..', 'service-worker.js'), 'utf-8');
-    expect(sw).toContain('design-tokens.css');
+    const assetManifest = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '..', 'lib', 'app-assets.json'), 'utf-8')
+    );
+    expect(assetManifest.precache_paths).toContain('./design-tokens.css');
   });
 
-  test('service worker caches theme-init.js', () => {
-    const sw = fs.readFileSync(path.resolve(__dirname, '..', 'service-worker.js'), 'utf-8');
-    expect(sw).toContain('theme-init.js');
+  test('service worker does not precache inline theme-init.js', () => {
+    const assetManifest = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '..', 'lib', 'app-assets.json'), 'utf-8')
+    );
+    expect(assetManifest.precache_paths).not.toContain('./theme-init.js');
   });
 
   test('service worker caches icon.svg', () => {
-    const sw = fs.readFileSync(path.resolve(__dirname, '..', 'service-worker.js'), 'utf-8');
-    expect(sw).toContain('icon.svg');
+    const assetManifest = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '..', 'lib', 'app-assets.json'), 'utf-8')
+    );
+    expect(assetManifest.precache_paths).toContain('./icon.svg');
   });
 
-  test('STATIC_ASSETS has no duplicates', () => {
-    const sw = fs.readFileSync(path.resolve(__dirname, '..', 'service-worker.js'), 'utf-8');
-    const match = sw.match(/const STATIC_ASSETS = \[([\s\S]*?)\];/);
-    expect(match).toBeTruthy();
-
-    const assets = match[1].match(/'([^']+)'/g).map(s => s.replace(/'/g, ''));
+  test('precache_paths has no duplicates', () => {
+    const assetManifest = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '..', 'lib', 'app-assets.json'), 'utf-8')
+    );
+    const assets = assetManifest.precache_paths;
     const unique = new Set(assets);
     expect(assets.length).toBe(unique.size);
   });
@@ -214,6 +219,7 @@ test.describe('Service Worker Cache', () => {
     const sw = fs.readFileSync(path.resolve(__dirname, '..', 'service-worker.js'), 'utf-8');
     expect(sw).toContain('.json');
     expect(sw).toContain('DATA_CACHE_NAME');
+    expect(sw).toContain('event.waitUntil(networkFetch');
   });
 
   test('service worker has offline fallback HTML', () => {


### PR DESCRIPTION
## Summary
Installed PWAs were at risk of staying on stale shells, and the asset/test/tooling setup had started to drift across the generator, template, service worker, and local validation flows. This PR keeps the app static on GitHub Pages while tightening freshness, compatibility, and developer ergonomics without adding new product features.

It introduces a shared `app-assets` manifest that drives copied assets, rendered tags, and service worker precache entries; updates the service worker and registration flow so fresh installs and updates are picked up more reliably; and refreshes runtime helpers for INP-era performance monitoring and safer theme bootstrap behavior.

## Key changes
- add `lib/app-assets.json` and `lib/app_assets.rb` as the single asset source of truth for the generator, HTML template, service worker, and tests
- refresh the PWA shell with manifest-driven precaching, skip-waiting activation flow, install asset coverage, and an updated `start_url`
- modernize client runtime support with INP/fallback performance reporting and less opaque theme init handling
- align local tooling and docs with current requirements and flows (`package.json`, Playwright build step, Ruby 4 `logger`, README/accessibility/mobile docs)
- update specs/tests for the new manifest layout and isolate render specs so they no longer dirty tracked fixture/data files during validation

## Notes
- This is a modernization and stability pass only; it intentionally avoids adding product features or changing the deployment model.
- The self-review pass ended with no unresolved high-confidence findings in the diff.

## Validation
- `bundle _2.7.2_ exec rspec spec/standings_spec.rb spec/end_to_end_spec.rb`
- `npx playwright test --config=playwright.config.js tests/app.spec.js tests/deep.spec.js tests/integration.spec.js tests/navigation.spec.js`
- `npx playwright test e2e/hockey-bet.spec.ts -g "loads without errors|Runtime health"`